### PR TITLE
docs: add motorola edge 30 to supported devices list

### DIFF
--- a/docs/repos.json
+++ b/docs/repos.json
@@ -40,6 +40,14 @@
         "devices": "Motorola Moto G84 5G"
     },
     {
+        "maintainer": "tuxdotrs",
+        "img": "https://avatars.githubusercontent.com/tuxdotrs?v=4",
+        "maintainer_link": "https://github.com/tuxdotrs",
+        "kernel_name": "android_kernel_motorola_sm7325",
+        "kernel_link": "https://github.com/tuxdotrs/android_kernel_motorola_sm7325",
+        "devices": "Motorola Edge 30"
+    },
+    {
         "maintainer": "whyakari",
         "img": "https://avatars.githubusercontent.com/whyakari?v=4",
         "maintainer_link": "https://github.com/whyakari",


### PR DESCRIPTION
Adds Motorola Edge 30 XT2203 (GKI 5.4.302) 